### PR TITLE
顧客側のCustomer関連画面のレイアウト&ヘッダー修正

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -40,7 +40,7 @@
               <%=  link_to items_path,class: 'btn btn-outline-light' do %>商品一覧<% end %>
             </li>
             <li class='mx-1'>
-              <%=  link_to items_path,class: 'btn btn-outline-light' do %>カート<% end %>
+              <%=  link_to cart_items_path,class: 'btn btn-outline-light' do %>カート<% end %>
             </li>
             <li class='mx-1'>
               <%= link_to destroy_customer_session_path, method: :delete,class: 'btn btn-outline-light' do %>ログアウト<% end %>
@@ -60,7 +60,7 @@
             <%=  link_to items_path,class: 'btn btn-outline-light' do %>商品一覧<% end %>
           </li>
           <li class='mx-1'>
-            <%=  link_to items_path,class: 'btn btn-outline-light' do %>カート<% end %>
+            <%=  link_to cart_items_path,class: 'btn btn-outline-light' do %>カート<% end %>
           </li>
           <li class='mx-1'>
             <%= link_to destroy_customer_session_path, method: :delete,class: 'btn btn-outline-light' do %>ログアウト<% end %>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -4,7 +4,7 @@
       <h4 class='alart alert-secondary'>会員情報編集</h4>
     </div>
   </div>
-    <div class='row justify-content-center'>
+    <div class='row py-3 col-md-5 justify-content-center'>
       <%= form_with url: customers_infomation_path, model: @customer, local:true do |f| %>
 
         <div class="row mb-3">
@@ -20,29 +20,30 @@
         </div>
 
         <div class="row mb-3">
-          <%= f.label :"郵便番号", class:"col-md-3" %>
+          <%= f.label :"郵便番号", class:"col-md-4" %>
           <%= f.text_field :postcode %>
         </div>
 
         <div class="row mb-3">
-          <%= f.label :"住所", class:"col-md-3" %>
+          <%= f.label :"住所", class:"col-md-4" %>
           <%= f.text_field :address %>
         </div>
 
         <div class="row mb-3">
-          <%= f.label :"電話番号", class:"col-md-3" %>
+          <%= f.label :"電話番号", class:"col-md-4" %>
           <%= f.text_field :telephone_number %>
         </div>
 
         <div class="row mb-3">
-          <%= f.label :"メールアドレス", class:"col-md-3" %>
+          <%= f.label :"メールアドレス", class:"col-md-4" %>
           <%= f.text_field :email %>
         </div>
 
 
-        <div class="actions">
+        <div class="row mb-3">
+          <div class="col-md-4"> </div>
           <%= f.submit "変更内容を保存",class: 'btn btn-sm btn-success' %>
-          <%= link_to "退会する", customers_unsubscribe_path(@customer), class: 'btn btn-sm btn-danger' %>
+          <%= link_to "退会する", customers_unsubscribe_path(@customer), class: 'offset-md-3 btn btn-sm btn-danger' %>
         </div>
       <% end %>
     </div>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -4,17 +4,17 @@
       <h4 class='alart alert-secondary'>会員情報編集</h4>
     </div>
   </div>
-    <div class='row py-3 col-md-5 justify-content-center'>
+    <div class='row py-3 col-md-8 align-content-start'>
       <%= form_with url: customers_infomation_path, model: @customer, local:true do |f| %>
 
-        <div class="row mb-3">
-          <%= f.label :"氏名", class:"col-md-3" %>
+        <div class="row mb-3 flex-nowrap">
+          <%= f.label :"氏名", class:"col-md-4" %>
           <%= f.text_field :last_name  %>
           <%= f.text_field :first_name, class:"offset-md-1 col-md-3" %>
         </div>
 
-        <div class="row mb-3">
-          <%= f.label :"フリガナ", class:"col-md-3" %>
+        <div class="row mb-3 flex-nowrap">
+          <%= f.label :"フリガナ", class:"col-md-4" %>
           <%= f.text_field :last_name_kana %>
           <%= f.text_field :first_name_kana, class:"offset-md-1 col-md-3" %>
         </div>
@@ -24,9 +24,9 @@
           <%= f.text_field :postcode %>
         </div>
 
-        <div class="row mb-3">
+        <div class="row mb-3 flex-nowrap">
           <%= f.label :"住所", class:"col-md-4" %>
-          <%= f.text_field :address %>
+          <%= f.text_field :address, class:"col-md-12" %>
         </div>
 
         <div class="row mb-3">
@@ -40,10 +40,10 @@
         </div>
 
 
-        <div class="row mb-3">
+        <div class="row mb-3 flex-nowrap">
           <div class="col-md-4"> </div>
-          <%= f.submit "変更内容を保存",class: 'btn btn-sm btn-success' %>
-          <%= link_to "退会する", customers_unsubscribe_path(@customer), class: 'offset-md-3 btn btn-sm btn-danger' %>
+          <%= f.submit "編集内容を保存",class: 'col-md-5 btn btn-sm btn-success' %>
+          <%= link_to "退会する", customers_unsubscribe_path(@customer), class: 'col-md-3 offset-md-6 btn btn-danger' %>
         </div>
       <% end %>
     </div>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -1,43 +1,51 @@
 <div class='container'>
-  <div class='row'>
-    <div class='col-md-4'>      
-      <h4>マイページ</h4>
-    </div>
+  <div class='row pt-3'>
+      <h4 class="alart alert-secondary">マイページ</h4>
   </div>
-    <div class='row'>
-      <h5>登録情報</h5>
-      <%= link_to "編集する", customers_information_edit_path, class: "btn btn btn-success" %>
+    <div class='row pt-3 pb-2'>
+          <h5 class='font-weight-bold mr-5'>登録情報</h5>
+          <%= link_to "編集する", customers_information_edit_path, class: "btn btn btn-success" %>
     </div>
-  </div>
-      
-      <table>
+
+    <div class='row my-3 col-md-5'>
+      <table class='table table-hover table-inverse table-bordered'>
         <tr>
-          <th>氏名</th>
+          <th class="table-active">氏名</th>
           <td><%= @customer.last_name %><%= @customer.first_name %></td>
         <tr>
-          <th>カナ</th>
+          <th class="table-active">カナ</th>
           <td><%= @customer.last_name_kana %><%= @customer.first_name_kana %></td>
         </tr>
         <tr>
-          <th>郵便番号</th>
+          <th class="table-active">郵便番号</th>
           <td><%= @customer.postcode %></td>
         </tr>
         <tr>
-          <th>住所</th>
+          <th class="table-active">住所</th>
           <td><%= @customer.address %></td>
         </tr>
         <tr>
-          <th>電話番号</th>
+          <th class="table-active">電話番号</th>
           <td><%= @customer.telephone_number %></td>
         </tr>
         <tr>
-          <th>メールアドレス</th>
+          <th class="table-active">メールアドレス</th>
           <td><%= @customer.email %></td>
       </table>
-      
-      <div>
-        <p>配送先</p>　　<%#= link_to "一覧を見る",addressのpath, class: 'btn btn-success' %>
+    </div>
+
+      <div class='row my-3 col-md-5'>
+        <div class="row mb-3 justify-content-center">
+            <h5 class='font-weight-bold mr-5'>配送先　</h5>
+            <%= link_to "一覧を見る",addresses_path, class: 'btn btn-primary btn-sm' %>
+        </div>
       </div>
-      <div>
-        <p>注文履歴</p>　<%#= link_to "一覧を見る",ordersのpath, class: 'btn btn-success' %>
+      <div class='row my-3 col-md-5'>
+        <div class="row mb-3 justify-content-center">
+            <h5 class='font-weight-bold mr-5'>注文履歴</h5>
+            <%= link_to "一覧を見る",orders_path, class: 'btn btn-primary btn-sm' %>
+        </div>
+
+
       </div>
+</div>

--- a/app/views/public/customers/unsubscribe.erb
+++ b/app/views/public/customers/unsubscribe.erb
@@ -1,16 +1,16 @@
-<div class='container'>
-  <div class='row justify-content-center'>
-    <h4>本当に退会しますか？</h4>
+<div class='container my-5 py-5'>
+  <div class='row pt-5 justify-content-center'>
+    <h3 class='font-weight-bold'>本当に退会しますか？</h3>
   </div>
-  <div class='row justify-content-center'>
-      <p class='text-center'>
+  <div class='row pt-5 pb-5 justify-content-center'>
+      <h4 class='text-center'>
         退会すると、会員登録情報や</br>
         これまでの購入履歴が閲覧できなくなります。</br>
         退会する場合は,「退会する」をクリックしてください。
-      </p>
+      </h4>
   </div>
-  <div class='row justify-content-center'>  
-    <%= link_to "退会しない", customers_my_page_path(@cutomer), class: 'btn btn-primary' %>
-    <%= link_to "退会する",  customers_withdraw_path(@cutomer), method: :patch, class: 'btn btn-danger' %>
+  <div class='row justify-content-center'>
+    <%= link_to "退会しない", customers_my_page_path(@cutomer), class: 'col-md-2 mx-2 btn btn-primary' %>
+    <%= link_to "退会する",  customers_withdraw_path(@cutomer), method: :patch, class: 'col-md-2 mx-2 btn btn-danger' %>
   </div>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,8 +15,8 @@ ActiveRecord::Schema.define(version: 2022_10_24_065053) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2022_10_24_065053) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -123,7 +123,6 @@ ActiveRecord::Schema.define(version: 2022_10_24_065053) do
     t.integer "postage", null: false
     t.integer "payment_method", default: 0, null: false
     t.integer "status", default: 0, null: false
-    t.integer "customer_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -105,6 +105,18 @@ ActiveRecord::Schema.define(version: 2022_10_23_040718) do
     t.integer "genre_id"
   end
 
+  create_table "orders", force: :cascade do |t|
+    t.string "postcode", null: false
+    t.string "address", null: false
+    t.string "name", null: false
+    t.integer "total_payment", null: false
+    t.integer "postage", null: false
+    t.integer "payment_method", default: 0, null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,5 +11,5 @@
 
 # Admin.create!(
 #     email: 'admin@test.com',
-#     password: 'pa ssword',
+#     password: 'password',
 # )


### PR DESCRIPTION
・顧客側のマイページ、登録情報編集画面、退会確認画面のレイアウトを整えました。
・ヘッダーのカートへの仮リンクを正しいリンクに訂正しました。