### PR TITLE
注文ステータスと製作ステータスの連動を実装

### DIFF
--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -1,8 +1,21 @@
 class Admin::OrderDetailsController < ApplicationController
+
   def update
     order_detail = OrderDetail.find(params[:id])
-    product_status = params[:order_detail][:product_status].to_i
-    order_detail.update(product_status: product_status)
-    redirect_to request.referer, notice: '製作ステータスを更新しました'
+    product_status = params[:order_detail][:product_status]
+    order = order_detail.order
+
+    order_detail.update(order_detail_params)
+    order.update(status: "in_production") if product_status == "is_making"
+    order.update(status: "preparing_shipment") if order.order_details.count == order.order_details.where(product_status: "completed").count
+
+    redirect_to request.referer
+
   end
+
+private
+  def order_detail_params
+      params.require(:order_detail).permit(:product_status)
+  end
+
 end

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -1,2 +1,8 @@
 class Admin::OrderDetailsController < ApplicationController
+  def update
+    order_detail = OrderDetail.find(params[:id])
+    product_status = params[:order_detail][:product_status].to_i
+    order_detail.update(product_status: product_status)
+    redirect_to request.referer, notice: '製作ステータスを更新しました'
+  end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -5,7 +5,14 @@ class Admin::OrdersController < ApplicationController
   end
 
   def update
+    @order = Order.find(params[:id])
+    @order.update(order_params)
+    redirect_to 
 
   end
 
+  private
+  def order_params
+    params.require(:order).permit(:status)
+  end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,17 +1,24 @@
 class Admin::OrdersController < ApplicationController
+
   def show
     @order = Order.find(params[:id])
-    @orders = @order.order_details.all
+    @order_details = @order.order_details
     @postage = 800
-
   end
 
   def update
     @order = Order.find(params[:id])
-    status = params[:order][:status].to_i
-    @order.update(status: status)
-    redirect_to admin_order_path(@order), notice: '注文ステータスを更新しました'
+    @order.update(order_params)
 
+    if params[:order][:status] == "confirm_deposit"
+     @order.order_details.update(product_status: "is_waiting")
+    end
+    redirect_to admin_order_path(@order)
   end
 
+private
+
+ def order_params
+   params.require(:order).permit(:status)
+ end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,18 +1,17 @@
 class Admin::OrdersController < ApplicationController
   def show
     @order = Order.find(params[:id])
+    @orders = @order.order_details.all
+    @postage = 800
 
   end
 
   def update
     @order = Order.find(params[:id])
-    @order.update(order_params)
-    redirect_to 
+    status = params[:order][:status].to_i
+    @order.update(status: status)
+    redirect_to admin_order_path(@order), notice: '注文ステータスを更新しました'
 
   end
 
-  private
-  def order_params
-    params.require(:order).permit(:status)
-  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,11 +9,12 @@ class Order < ApplicationRecord
   enum payment_method: { credit_card: 0, transfer: 1}
 
   enum status: {
-     "入金待ち": 0,
-     "入金確認": 1,
-     "製作中": 2,
-     "発送準備中": 3,
-    " 発送済み": 4
+
+     waiting_deposit: 0,
+     confirm_deposit: 1,
+     in_production: 2,
+     preparing_shipment: 3,
+     shipped: 4
   }
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -8,11 +8,11 @@ class Order < ApplicationRecord
   enum payment_method: { credit_card: 0, transfer: 1}
 
   enum status: {
-     "入金待ち":0,
-     "入金確認":1,
-     "製作中":2,
-     "発送準備中":3,
-     "発送済み":4
+     入金待ち: 0,
+     入金確認: 1,
+     製作中: 2,
+     発送準備中: 3,
+     発送済み: 4
   }
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,14 +5,15 @@ class Order < ApplicationRecord
  has_many :order_details
  has_many :items, through: :order_details
 
+
   enum payment_method: { credit_card: 0, transfer: 1}
 
   enum status: {
-     入金待ち: 0,
-     入金確認: 1,
-     製作中: 2,
-     発送準備中: 3,
-     発送済み: 4
+     "入金待ち": 0,
+     "入金確認": 1,
+     "製作中": 2,
+     "発送準備中": 3,
+    " 発送済み": 4
   }
 
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -2,12 +2,8 @@ class OrderDetail < ApplicationRecord
   belongs_to :order
   belongs_to :item
 
-  enum product_status: {
-     "着手不可": 0,
-     "製作待ち": 1,
-     "製作中": 2,
-     "製作完了": 3
-  }
+  enum product_status: {cannot_make: 0, is_waiting: 1, is_making: 2, completed: 3 }
+
 
     ## 小計を求めるメソッド
   def subtotal

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -1,4 +1,17 @@
 class OrderDetail < ApplicationRecord
   belongs_to :order
   belongs_to :item
+
+  enum product_status: {
+     "着手不可": 0,
+     "製作待ち": 1,
+     "製作中": 2,
+     "製作完了": 3
+  }
+
+    ## 小計を求めるメソッド
+  def subtotal
+      item.add_tax_price*amount
+  end
+
 end

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -36,7 +36,7 @@
                 <%= @total_amount.to_s %>
             </th>
 
-            <th><%= order.status%></th>
+            <th><%= order.status_i18n %></th>
           </tr>
           <% end %>
         </tbody>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -21,8 +21,8 @@
     <tr>
       <td>注文ステータス　</td>
       <td>
-        <%= form_with model: Order, url: admin_order_path(@order), method: :patch do |f| %>
-        <%= f.select :status, options_for_select(Order.statuses.to_a, selected: @order.status_before_type_cast) %>
+        <%= form_with model: @order, url: admin_order_path(@order), method: :patch do |f| %>
+        <%= f.select :status, Order.statuses.keys.map {|k| [I18n.t("enums.order.status.#{k}"), k]} %>
         <%= f.submit "更新"  %>
         <% end %>
       </td>
@@ -42,15 +42,15 @@
   </thead>
 
   <tbody>
-    <% @orders.each do |order_detail| %>
+    <% @order_details.each do |order_detail| %>
     <tr>
       <td><%= order_detail.item.name %></td>
       <td><%= (order_detail.item.add_tax_price).to_s(:delimited) %></td>
       <td><%= order_detail.amount %></td>
       <td><%= (order_detail.subtotal).to_s(:delimited) %></td>
       <td>
-        <%= form_with model: OrderDetail, url: admin_order_detail_path(order_detail), method: :patch do |f| %>
-        <%= f.select :product_status, options_for_select(OrderDetail.product_statuses.to_a, selected: order_detail.product_status_before_type_cast) %>
+        <%= form_with model: order_detail, url: admin_order_detail_path(order_detail), method: :patch do |f| %>
+        <%= f.select :product_status, OrderDetail.product_statuses.keys.map {|k| [I18n.t("enums.order_detail.product_status.#{k}"), k]} %>
         <%= f.submit "更新"  %>
         <% end %>
       </td>
@@ -65,22 +65,22 @@
       <td>商品合計</td>
       <td>
           <% @sum = 0 %>
-          <% @orders.each do |order_detail| %>
+          <% @order_details.each do |order_detail| %>
           <% (order_detail.subtotal).to_i %>
           <% @sum += (order_detail.subtotal).to_i %>
           <% end %>
-          <%= @sum.to_s %>
+          <%= @sum.to_s %>円
       </td>
     </tr>
 
     <tr>
       <td>送料</td>
-      <td><%= @postage %></td>
+      <td><%= @postage %>円</td>
     </tr>
 
     <tr>
       <td>請求金額合計</td>
-      <td><%= (@sum + @postage).to_s %></td>
+      <td><%= (@sum + @postage).to_s %>円</td>
     </tr>
 
   </tbody>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -11,7 +11,8 @@
     </tr>
     <tr>
       <td>配送先</td>
-      <td><%= @order.postcode %><%= @order.address %><%= @order.name %></td>
+      <td>〒<%= @order.postcode %><%= @order.address %></br>
+      <%= @order.name %></td>
     </tr>
     <tr>
       <td>支払方法</td>
@@ -21,7 +22,7 @@
       <td>注文ステータス　</td>
       <td>
         <%= form_with model: Order, url: admin_order_path(@order), method: :patch do |f| %>
-        <%= f.select :status, *[0..4]%>
+        <%= f.select :status, [['入金待ち'],['入金確認'], ['製作中'], ['発送準備中'],['発送済み']] %>
         <%= f.submit "更新"  %>
         <% end %>
       </td>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,6 +1,6 @@
 <h1>注文履歴詳細</h1>
 <table>
-  <body>
+  <tbody>
     <tr>
       <td>購入者</td>
       <td><%= @order.name %></td>
@@ -22,10 +22,66 @@
       <td>注文ステータス　</td>
       <td>
         <%= form_with model: Order, url: admin_order_path(@order), method: :patch do |f| %>
-        <%= f.select :status, [['入金待ち'],['入金確認'], ['製作中'], ['発送準備中'],['発送済み']] %>
+        <%= f.select :status, options_for_select(Order.statuses.to_a, selected: @order.status_before_type_cast) %>
         <%= f.submit "更新"  %>
         <% end %>
       </td>
     </td>
-  </body>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr>
+      <th>商品名</th>
+      <th>単価（税込）</th>
+      <th>数量</th>
+      <th>小計</th>
+      <th>製作ステータス</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @orders.each do |order_detail| %>
+    <tr>
+      <td><%= order_detail.item.name %></td>
+      <td><%= (order_detail.item.add_tax_price).to_s(:delimited) %></td>
+      <td><%= order_detail.amount %></td>
+      <td><%= (order_detail.subtotal).to_s(:delimited) %></td>
+      <td>
+        <%= form_with model: OrderDetail, url: admin_order_detail_path(order_detail), method: :patch do |f| %>
+        <%= f.select :product_status, options_for_select(OrderDetail.product_statuses.to_a, selected: order_detail.product_status_before_type_cast) %>
+        <%= f.submit "更新"  %>
+        <% end %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<table>
+  <tbody>
+    <tr>
+      <td>商品合計</td>
+      <td>
+          <% @sum = 0 %>
+          <% @orders.each do |order_detail| %>
+          <% (order_detail.subtotal).to_i %>
+          <% @sum += (order_detail.subtotal).to_i %>
+          <% end %>
+          <%= @sum.to_s %>
+      </td>
+    </tr>
+
+    <tr>
+      <td>送料</td>
+      <td><%= @postage %></td>
+    </tr>
+
+    <tr>
+      <td>請求金額合計</td>
+      <td><%= (@sum + @postage).to_s %></td>
+    </tr>
+
+  </tbody>
 </table>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -20,7 +20,7 @@
             <%= f.hidden_field :item_id, :value => cart_item.item_id %>
             <%= f.select :amount, *[1..10], {selected: cart_item.amount}  %>
             <%= f.submit "変更", class: "btn btn-sm btn-success" %>
-            <% end %>
+      <% end %>
      　  </th>
         <th><%= (cart_item.subtotal).to_s(:delimited) %></th>
         <th><%= link_to "削除する", cart_item_path(cart_item.id), class: "btn btn-danger", method: :delete %></th>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,15 +10,3 @@
         payment_method:
           credit_card: "クレジットカード"
           transfer: "銀行振込"
-
-  # ja:
-  #   enums:
-  #     order:
-  #       status:
-          
-  #   "入金待ち":0,
-  #   "入金確認":1,
-  #   "製作中":2,
-  #   "発送準備中":3,
-  #   "発送済み":4
-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,3 +10,15 @@
         payment_method:
           credit_card: "クレジットカード"
           transfer: "銀行振込"
+
+  # ja:
+  #   enums:
+  #     order:
+  #       status:
+          
+  #   "入金待ち":0,
+  #   "入金確認":1,
+  #   "製作中":2,
+  #   "発送準備中":3,
+  #   "発送済み":4
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,9 +4,22 @@
         is_on_sale:
           on_sale: "販売中"
           sold_out: "販売停止中"
-  ja:
-    enums:
+
       order:
         payment_method:
           credit_card: "クレジットカード"
           transfer: "銀行振込"
+
+        status:
+          waiting_deposit: '入金待ち'
+          confirm_deposit: '入金確認'
+          in_production: '製作中'
+          preparing_shipment: '発送準備中'
+          shipped: '発送済み'
+
+      order_detail:
+        product_status:
+          cannot_make: '製作不可'
+          is_waiting: '製作待ち'
+          is_making: '製作中'
+          completed: '製作完了'


### PR DESCRIPTION
## 注文ステータスと製作ステータスの連動を下記の通り実装しました

- 注文ステータスが"入金確認"になったら、紐づく注文商品全ての製作ステータスを"製作待ち"に更新する
- 紐づく注文商品の製作ステータスが1つでも"製作中"になったら、注文ステータスを"製作中"に更新する

- 紐づく注文商品全ての製作ステータスが"製作完了"になったら、注文ステータスを"発送準備中"に更新する